### PR TITLE
Feature/logo styles fix

### DIFF
--- a/partner-page.html
+++ b/partner-page.html
@@ -1,4 +1,4 @@
-<p>These are some of our partners that are committed to providing educational resources for the families of their communities. We work with a wide range of organizations, including sports associations and libraries.</p>
+<p>These are some of our partners that are committed to providing educational resources for the families of their communities. We work with a wide range of organizations across North America and regionally, including sports associations and libraries.</p>
 <h1 class="partner-title"><b>North American Partners</b></h1>
 <hr/>
 <div class="partner-container">
@@ -38,7 +38,7 @@
   </div>
   <div class="partner-item">
     <a href="https://forces.ca/en/" target="_blank" rel="noopener noreferrer"> 
-      <img src="https://cfmws.ca/cfmws/media/images/logo_header_en.svg" alt="Canadian Forces Morale and Welfare Services Logo"/>
+      <img style="height:150px;" src="https://cfmws.ca/cfmws/media/images/logo_header_en.svg" alt="Canadian Forces Morale and Welfare Services Logo"/>
     </a>
     <p>Canadian Armed Forces Morale and Welfare Services</p>
   </div>

--- a/styles.html
+++ b/styles.html
@@ -3,17 +3,27 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    .partner-item {
+    margin-top: 40px;
+    margin-bottom: 40px;
+  }
+
+  .partner-container > .partner-item {
       display: flex;
       flex-direction: column;
       align-items: center;
-      width: 300px;
+      width: 250px;
       border: 1px solid #ffffff;
     }
 
-    .partner-item > a > img {
-      height: 250px;
-    }
+  .partner-item > a > img {
+    height: auto;
+  }
+  
+  .partner-item > p {
+    position: relative;
+    top: -25px;
+    text-align: center;
+    text-decoration-line: underline;
   }
 
   .partner-item:hover {


### PR DESCRIPTION
Changes:
* Main text intro has had additional information added to it.
* The CAF SVG needed an inline height provided to it since it is an SVG, otherwise does not display without a given height/width.
* Margins were added to give better spacing between partner items.
* Width of partner items was reduced
* Text is centered and aligned closer to partner images, as well as underlined
* Removed nesting of CSS selectors that are for SCSS.
* Logos adjust to their automatic height based on the given width now.