### PR TITLE
Fix/domain differences

### DIFF
--- a/partner-page.html
+++ b/partner-page.html
@@ -1,22 +1,45 @@
-<p>Castle Rock Research works with partners that are committed to providing educational resources for the families of their communities. We work with a wide range of organizations across North America and regionally, including sports associations, government and military, and libraries.</p>
+<p class="partner-desc">
+  Castle Rock Research works with partners that are committed to providing
+  educational resources for the families of their communities. We work with a
+  wide range of organizations across North America and regionally, including
+  sports associations, government and military, and libraries.
+</p>
 <h1 class="partner-title"><b>North American Partners</b></h1>
-<hr/>
+<hr />
 <div class="partner-container">
   <div class="partner-item">
-    <a href="https://www.ontariosoccer.net" target="_blank" rel="noopener noreferrer">
-      <img src="https://images.squarespace-cdn.com/content/v1/527b2a10e4b07965b54c4418/d852d927-fefb-48e8-8c93-f45811377c60/Ontario+Soccer.png" alt="Ontario Soccer Logo"/>
+    <a
+      href="https://www.ontariosoccer.net"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <img
+        src="https://images.squarespace-cdn.com/content/v1/527b2a10e4b07965b54c4418/d852d927-fefb-48e8-8c93-f45811377c60/Ontario+Soccer.png"
+        alt="Ontario Soccer Logo"
+      />
     </a>
     <p>Ontario Soccer</p>
   </div>
   <div class="partner-item">
-    <a href="https://www.americanyouthfootball.com/" target="_blank" rel="noopener noreferrer">
-      <img style="height:90px;" src="https://www.americanyouthfootball.com/images/logo.png" alt="American Youth Football & Cheer Logo"/>
+    <a
+      href="https://www.americanyouthfootball.com/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <img
+        style="height: 90px"
+        src="https://www.americanyouthfootball.com/images/logo.png"
+        alt="American Youth Football & Cheer Logo"
+      />
     </a>
     <p>American Youth Football & Cheer</p>
   </div>
-    <div class="partner-item">
+  <div class="partner-item">
     <a href="https://cjga.com" target="_blank" rel="noopener noreferrer">
-      <img src="https://images.squarespace-cdn.com/content/527b2a10e4b07965b54c4418/d27641c8-f7a2-42e1-808e-eb1a0dbd83b4/2016-CJGA-Logo-Transparent-with-white-border.png" alt="Canadian Junior Golf Association Logo"/>
+      <img
+        src="https://images.squarespace-cdn.com/content/527b2a10e4b07965b54c4418/d27641c8-f7a2-42e1-808e-eb1a0dbd83b4/2016-CJGA-Logo-Transparent-with-white-border.png"
+        alt="Canadian Junior Golf Association Logo"
+      />
     </a>
     <p>Canadian Junior Golf Association</p>
   </div>
@@ -24,44 +47,82 @@
 <div class="partner-container">
   <div class="partner-item">
     <a href="https://playncs.com" target="_blank" rel="noopener noreferrer">
-      <img src="https://images.squarespace-cdn.com/content/v1/52d42a5be4b021f8239bcbbf/8950a0f2-117b-4d2e-ad65-cab8b457665a/National-Championship-Sports-transparent.png" alt="National Championship Sports Logo"/>
+      <img
+        src="https://images.squarespace-cdn.com/content/v1/52d42a5be4b021f8239bcbbf/8950a0f2-117b-4d2e-ad65-cab8b457665a/National-Championship-Sports-transparent.png"
+        alt="National Championship Sports Logo"
+      />
     </a>
     <p>National Championship Sports</p>
   </div>
-    <div class="partner-item">
-    <a href="https://challengersports.com/" target="_blank" rel="noopener noreferrer">
-      <img style="height:90px;" src="https://images.squarespace-cdn.com/content/52d42a5be4b021f8239bcbbf/acffef97-6050-48d7-ab49-d9b32a15cdce/ChallengerSports-2021-Official-Logo+copy.png" alt="Challenger Sports Logo"/>
+  <div class="partner-item">
+    <a
+      href="https://challengersports.com/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <img
+        style="height: 90px"
+        src="https://images.squarespace-cdn.com/content/52d42a5be4b021f8239bcbbf/acffef97-6050-48d7-ab49-d9b32a15cdce/ChallengerSports-2021-Official-Logo+copy.png"
+        alt="Challenger Sports Logo"
+      />
     </a>
     <p>Challenger Sports</p>
   </div>
   <div class="partner-item">
-    <a href="https://forces.ca/en/" target="_blank" rel="noopener noreferrer"> 
-      <img style="height:90px;" src="https://cfmws.ca/cfmws/media/images/logo_header_en.svg" alt="Canadian Forces Morale and Welfare Services Logo"/>
+    <a href="https://forces.ca/en/" target="_blank" rel="noopener noreferrer">
+      <img
+        style="height: 90px"
+        src="https://cfmws.ca/cfmws/media/images/logo_header_en.svg"
+        alt="Canadian Forces Morale and Welfare Services Logo"
+      />
     </a>
     <p>Canadian Armed Forces Morale and Welfare Services</p>
   </div>
 </div>
-<br><hr/>
+<br />
+<hr />
 <h1 class="partner-title"><b>Regional Partners</b></h1>
-<hr/>
+<hr />
 <div class="partner-container">
   <div class="partner-item">
-    <a href="https://www.sfbrownbombers.org" target="_blank" rel="noopener noreferrer">
-      <img src="https://images.squarespace-cdn.com/content/v1/603d5813131d6a78e0a12ea1/1615376397012-AVO3XGA99YQ5D3QCHVS5/logo.png" alt="San Francisco Brown Bombers Logo"/>
+    <a
+      href="https://www.sfbrownbombers.org"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <img
+        src="https://images.squarespace-cdn.com/content/v1/603d5813131d6a78e0a12ea1/1615376397012-AVO3XGA99YQ5D3QCHVS5/logo.png"
+        alt="San Francisco Brown Bombers Logo"
+      />
     </a>
     <p>San Francisco Brown Bombers</p>
   </div>
   <div class="partner-item">
-    <a href="https://risingstarsfootballacademy.com" target="_blank" rel="noopener noreferrer">
-      <img src="https://risingstarsfootballacademy.com/wp-content/uploads/2021/12/RSFA-2021-Logo.png" alt="Rising Stars Football Academy Logo"/>
+    <a
+      href="https://risingstarsfootballacademy.com"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <img
+        src="https://risingstarsfootballacademy.com/wp-content/uploads/2021/12/RSFA-2021-Logo.png"
+        alt="Rising Stars Football Academy Logo"
+      />
     </a>
     <p>Rising Stars Football Academy</p>
   </div>
 </div>
-<br><hr/>
+<br />
+<hr />
 <div class="library-partners-banner">
-  <a href="https://castlerockresearch.com/solaro-for-libraries" target="_blank" rel="noopener noreferrer">
-    <img src="https://images.squarespace-cdn.com/content/527b2a10e4b07965b54c4418/a37fc954-327f-4406-9cb6-c3a47d2536da/LibraryPartnersBanner.png" alt="Our Library Partners"/>
-  </a>  
+  <a
+    href="https://castlerockresearch.com/solaro-for-libraries"
+    target="_blank"
+    rel="noopener noreferrer"
+  >
+    <img
+      src="https://images.squarespace-cdn.com/content/527b2a10e4b07965b54c4418/a37fc954-327f-4406-9cb6-c3a47d2536da/LibraryPartnersBanner.png"
+      alt="Our Library Partners"
+    />
+  </a>
 </div>
-<hr/>
+<hr />

--- a/styles.html
+++ b/styles.html
@@ -33,7 +33,7 @@
   .partner-item > p {
     position: relative;
     top: -10px;
-    font-size: 16px;
+    font-size: 18px;
     text-align: center;
     text-decoration-line: underline;
     margin: 0;

--- a/styles.html
+++ b/styles.html
@@ -11,6 +11,10 @@
     margin-bottom: 40px;
   }
 
+  .partner-desc {
+    font-size: 1.5em;
+  }
+
   .partner-container > .partner-item {
     display: flex;
     flex-direction: column;
@@ -28,6 +32,7 @@
   .partner-item > p {
     position: relative;
     top: -10px;
+    font-size: 16px;
     text-align: center;
     text-decoration-line: underline;
     margin: 0;

--- a/styles.html
+++ b/styles.html
@@ -11,11 +11,6 @@
     margin-bottom: 40px;
   }
 
-  .partner-desc {
-    font-size: 22px;
-    line-height: 24px;
-  }
-
   .partner-container > .partner-item {
     display: flex;
     flex-direction: column;
@@ -32,8 +27,6 @@
 
   .partner-item > p {
     position: relative;
-    top: -10px;
-    font-size: 18px;
     text-align: center;
     text-decoration-line: underline;
     margin: 0;

--- a/styles.html
+++ b/styles.html
@@ -12,7 +12,8 @@
   }
 
   .partner-desc {
-    font-size: 1.5em;
+    font-size: 22px;
+    line-height: 24px;
   }
 
   .partner-container > .partner-item {


### PR DESCRIPTION
This PR Only fixes two things:
* Removes the top property in styles to prevent the text from running over images on specific domains. This seems specific to the squarespace domain it is on, as sizing seems inconsistent due to the "you are on the .ca website!" banner. I wish there was a way around that banner for Canadian visitors.
* Formatted all text using prettier because it's easier to read.